### PR TITLE
remove k8s-rbac-proxy

### DIFF
--- a/charts/sn-operator/templates/deployment.yaml
+++ b/charts/sn-operator/templates/deployment.yaml
@@ -33,24 +33,6 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
       - args:
-        - --secure-listen-address=0.0.0.0:8443
-        - --upstream=http://127.0.0.1:8080/
-        - --logtostderr=true
-        - --v=0
-        image: "{{ .Values.image.kubeRbacProxy.registry }}/{{ .Values.image.kubeRbacProxy.repository }}:{{ .Values.image.kubeRbacProxy.tag }}"
-        name: kube-rbac-proxy
-        ports:
-        - containerPort: 8443
-          name: https
-          protocol: TCP
-        resources:
-          limits:
-            cpu: 500m
-            memory: 128Mi
-          requests:
-            cpu: 5m
-            memory: 64Mi
-      - args:
         - --health-probe-bind-address=:8081
         - --metrics-bind-address=127.0.0.1:8080
         - --leader-elect

--- a/charts/sn-operator/values.yaml
+++ b/charts/sn-operator/values.yaml
@@ -16,15 +16,6 @@ image:
     # -- Image tag, it can override the image tag whose default is the chart appVersion.
     tag: ""
 
-  # kube-rbac-proxy container
-  kubeRbacProxy:
-    # -- Specififies the registry of images, especially when user want to use a different image hub
-    registry: gcr.io
-    # -- The full repo name for image.
-    repository: kubebuilder/kube-rbac-proxy
-    # -- Image tag, it can override the image tag whose default is the chart appVersion.
-    tag: "v0.14.1"
-
 # -- Specifies image pull secrets for private registry, the format is `- name: gcr`
 imagePullSecrets: []
 # If you want to specify secrets, follow this format


### PR DESCRIPTION
remove k8s-rbac-proxy in private cloud helm chart. it is not required and has a critical cve unresolved.