### PR TITLE
Upgrade private cloud sn-operator to 0.14.2 version

### DIFF
--- a/charts/sn-operator/Chart.yaml
+++ b/charts/sn-operator/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v0.13.3
+version: v0.14.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.13.12"
+appVersion: "v0.14.2"
 
 # This is a semver range of compatible Kubernetes versions. Helm will validate the version
 # constraints when installing the chart and fail if the cluster runs an unsupported Kubernetes version

--- a/charts/sn-operator/crds/bookkeeper.streamnative.io_bookkeeperclusters.yaml
+++ b/charts/sn-operator/crds/bookkeeper.streamnative.io_bookkeeperclusters.yaml
@@ -1794,6 +1794,8 @@ spec:
                                     properties:
                                       name:
                                         type: string
+                                      request:
+                                        type: string
                                     required:
                                     - name
                                     type: object
@@ -1973,6 +1975,8 @@ spec:
                             items:
                               properties:
                                 name:
+                                  type: string
+                                request:
                                   type: string
                               required:
                               - name
@@ -2307,6 +2311,8 @@ spec:
                                   items:
                                     properties:
                                       name:
+                                        type: string
+                                      request:
                                         type: string
                                     required:
                                     - name
@@ -4002,6 +4008,8 @@ spec:
                                 properties:
                                   name:
                                     type: string
+                                  request:
+                                    type: string
                                 required:
                                 - name
                                 type: object
@@ -4181,6 +4189,8 @@ spec:
                         items:
                           properties:
                             name:
+                              type: string
+                            request:
                               type: string
                           required:
                           - name
@@ -4515,6 +4525,8 @@ spec:
                               items:
                                 properties:
                                   name:
+                                    type: string
+                                  request:
                                     type: string
                                 required:
                                 - name

--- a/charts/sn-operator/crds/k8s.streamnative.io_agentfunctions.yaml
+++ b/charts/sn-operator/crds/k8s.streamnative.io_agentfunctions.yaml
@@ -430,6 +430,33 @@ spec:
                         - keySecretKey
                         - keySecretName
                         type: object
+                      plainAuthConfig:
+                        properties:
+                          passwordKey:
+                            type: string
+                          secretName:
+                            type: string
+                          usernameKey:
+                            type: string
+                        required:
+                        - secretName
+                        type: object
+                      scramAuthConfig:
+                        properties:
+                          hashAlgorithm:
+                            enum:
+                            - SHA-256
+                            - SHA-512
+                            type: string
+                          passwordKey:
+                            type: string
+                          secretName:
+                            type: string
+                          usernameKey:
+                            type: string
+                        required:
+                        - secretName
+                        type: object
                     type: object
                   bootstrapServers:
                     type: string
@@ -437,6 +464,38 @@ spec:
                     properties:
                       enabled:
                         type: boolean
+                      keyStoreConfig:
+                        properties:
+                          fileKey:
+                            type: string
+                          keyPasswordKey:
+                            type: string
+                          passwordKey:
+                            type: string
+                          secretName:
+                            type: string
+                          type:
+                            enum:
+                            - JKS
+                            - PEM
+                            - PKCS12
+                            type: string
+                        type: object
+                      trustStoreConfig:
+                        properties:
+                          fileKey:
+                            type: string
+                          passwordKey:
+                            type: string
+                          secretName:
+                            type: string
+                          type:
+                            enum:
+                            - JKS
+                            - PEM
+                            - PKCS12
+                            type: string
+                        type: object
                     type: object
                 type: object
               kafkaConfig:
@@ -1859,6 +1918,8 @@ spec:
                                 properties:
                                   name:
                                     type: string
+                                  request:
+                                    type: string
                                 required:
                                 - name
                                 type: object
@@ -2167,6 +2228,8 @@ spec:
                           type: integer
                         type: array
                         x-kubernetes-list-type: atomic
+                      supplementalGroupsPolicy:
+                        type: string
                       sysctls:
                         items:
                           properties:
@@ -2637,6 +2700,8 @@ spec:
                                 properties:
                                   name:
                                     type: string
+                                  request:
+                                    type: string
                                 required:
                                 - name
                                 type: object
@@ -2917,10 +2982,12 @@ spec:
                             diskURI:
                               type: string
                             fsType:
+                              default: ext4
                               type: string
                             kind:
                               type: string
                             readOnly:
+                              default: false
                               type: boolean
                           required:
                           - diskName
@@ -3297,6 +3364,13 @@ spec:
                           required:
                           - path
                           type: object
+                        image:
+                          properties:
+                            pullPolicy:
+                              type: string
+                            reference:
+                              type: string
+                          type: object
                         iscsi:
                           properties:
                             chapAuthDiscovery:
@@ -3310,6 +3384,7 @@ spec:
                             iqn:
                               type: string
                             iscsiInterface:
+                              default: default
                               type: string
                             lun:
                               format: int32
@@ -3558,6 +3633,7 @@ spec:
                             image:
                               type: string
                             keyring:
+                              default: /etc/ceph/keyring
                               type: string
                             monitors:
                               items:
@@ -3565,6 +3641,7 @@ spec:
                               type: array
                               x-kubernetes-list-type: atomic
                             pool:
+                              default: rbd
                               type: string
                             readOnly:
                               type: boolean
@@ -3576,6 +3653,7 @@ spec:
                               type: object
                               x-kubernetes-map-type: atomic
                             user:
+                              default: admin
                               type: string
                           required:
                           - image
@@ -3584,6 +3662,7 @@ spec:
                         scaleIO:
                           properties:
                             fsType:
+                              default: xfs
                               type: string
                             gateway:
                               type: string
@@ -3601,6 +3680,7 @@ spec:
                             sslEnabled:
                               type: boolean
                             storageMode:
+                              default: ThinProvisioned
                               type: string
                             storagePool:
                               type: string
@@ -3886,6 +3966,8 @@ spec:
                     items:
                       properties:
                         name:
+                          type: string
+                        request:
                           type: string
                       required:
                       - name
@@ -4196,9 +4278,7 @@ spec:
                 - actualWindowFunctionClassName
                 type: object
             required:
-            - ""
             - agent
-            - kafka
             type: object
           status:
             properties:

--- a/charts/sn-operator/crds/k8s.streamnative.io_apikeys.yaml
+++ b/charts/sn-operator/crds/k8s.streamnative.io_apikeys.yaml
@@ -77,6 +77,8 @@ spec:
                         type: array
                       currentKid:
                         type: string
+                      disableV1Routes:
+                        type: boolean
                       logLevel:
                         enum:
                         - panic
@@ -286,6 +288,8 @@ spec:
                         items:
                           properties:
                             name:
+                              type: string
+                            request:
                               type: string
                           required:
                           - name

--- a/charts/sn-operator/crds/k8s.streamnative.io_consoles.yaml
+++ b/charts/sn-operator/crds/k8s.streamnative.io_consoles.yaml
@@ -814,6 +814,8 @@ spec:
                                 properties:
                                   name:
                                     type: string
+                                  request:
+                                    type: string
                                 required:
                                 - name
                                 type: object
@@ -993,6 +995,8 @@ spec:
                         items:
                           properties:
                             name:
+                              type: string
+                            request:
                               type: string
                           required:
                           - name
@@ -1327,6 +1331,8 @@ spec:
                               items:
                                 properties:
                                   name:
+                                    type: string
+                                  request:
                                     type: string
                                 required:
                                 - name

--- a/charts/sn-operator/crds/k8s.streamnative.io_kafkaconnects.yaml
+++ b/charts/sn-operator/crds/k8s.streamnative.io_kafkaconnects.yaml
@@ -389,6 +389,33 @@ spec:
                         - keySecretKey
                         - keySecretName
                         type: object
+                      plainAuthConfig:
+                        properties:
+                          passwordKey:
+                            type: string
+                          secretName:
+                            type: string
+                          usernameKey:
+                            type: string
+                        required:
+                        - secretName
+                        type: object
+                      scramAuthConfig:
+                        properties:
+                          hashAlgorithm:
+                            enum:
+                            - SHA-256
+                            - SHA-512
+                            type: string
+                          passwordKey:
+                            type: string
+                          secretName:
+                            type: string
+                          usernameKey:
+                            type: string
+                        required:
+                        - secretName
+                        type: object
                     type: object
                   bootstrapServers:
                     type: string
@@ -396,6 +423,38 @@ spec:
                     properties:
                       enabled:
                         type: boolean
+                      keyStoreConfig:
+                        properties:
+                          fileKey:
+                            type: string
+                          keyPasswordKey:
+                            type: string
+                          passwordKey:
+                            type: string
+                          secretName:
+                            type: string
+                          type:
+                            enum:
+                            - JKS
+                            - PEM
+                            - PKCS12
+                            type: string
+                        type: object
+                      trustStoreConfig:
+                        properties:
+                          fileKey:
+                            type: string
+                          passwordKey:
+                            type: string
+                          secretName:
+                            type: string
+                          type:
+                            enum:
+                            - JKS
+                            - PEM
+                            - PKCS12
+                            type: string
+                        type: object
                     type: object
                 type: object
               logTopic:
@@ -1787,6 +1846,8 @@ spec:
                                 properties:
                                   name:
                                     type: string
+                                  request:
+                                    type: string
                                 required:
                                 - name
                                 type: object
@@ -2095,6 +2156,8 @@ spec:
                           type: integer
                         type: array
                         x-kubernetes-list-type: atomic
+                      supplementalGroupsPolicy:
+                        type: string
                       sysctls:
                         items:
                           properties:
@@ -2565,6 +2628,8 @@ spec:
                                 properties:
                                   name:
                                     type: string
+                                  request:
+                                    type: string
                                 required:
                                 - name
                                 type: object
@@ -2845,10 +2910,12 @@ spec:
                             diskURI:
                               type: string
                             fsType:
+                              default: ext4
                               type: string
                             kind:
                               type: string
                             readOnly:
+                              default: false
                               type: boolean
                           required:
                           - diskName
@@ -3225,6 +3292,13 @@ spec:
                           required:
                           - path
                           type: object
+                        image:
+                          properties:
+                            pullPolicy:
+                              type: string
+                            reference:
+                              type: string
+                          type: object
                         iscsi:
                           properties:
                             chapAuthDiscovery:
@@ -3238,6 +3312,7 @@ spec:
                             iqn:
                               type: string
                             iscsiInterface:
+                              default: default
                               type: string
                             lun:
                               format: int32
@@ -3486,6 +3561,7 @@ spec:
                             image:
                               type: string
                             keyring:
+                              default: /etc/ceph/keyring
                               type: string
                             monitors:
                               items:
@@ -3493,6 +3569,7 @@ spec:
                               type: array
                               x-kubernetes-list-type: atomic
                             pool:
+                              default: rbd
                               type: string
                             readOnly:
                               type: boolean
@@ -3504,6 +3581,7 @@ spec:
                               type: object
                               x-kubernetes-map-type: atomic
                             user:
+                              default: admin
                               type: string
                           required:
                           - image
@@ -3512,6 +3590,7 @@ spec:
                         scaleIO:
                           properties:
                             fsType:
+                              default: xfs
                               type: string
                             gateway:
                               type: string
@@ -3529,6 +3608,7 @@ spec:
                             sslEnabled:
                               type: boolean
                             storageMode:
+                              default: ThinProvisioned
                               type: string
                             storagePool:
                               type: string
@@ -3814,6 +3894,8 @@ spec:
                     items:
                       properties:
                         name:
+                          type: string
+                        request:
                           type: string
                       required:
                       - name
@@ -4124,7 +4206,6 @@ spec:
                 - actualWindowFunctionClassName
                 type: object
             required:
-            - ""
             - kafka
             type: object
           status:

--- a/charts/sn-operator/crds/k8s.streamnative.io_mqttproxies.yaml
+++ b/charts/sn-operator/crds/k8s.streamnative.io_mqttproxies.yaml
@@ -959,6 +959,8 @@ spec:
                                 properties:
                                   name:
                                     type: string
+                                  request:
+                                    type: string
                                 required:
                                 - name
                                 type: object
@@ -1138,6 +1140,8 @@ spec:
                         items:
                           properties:
                             name:
+                              type: string
+                            request:
                               type: string
                           required:
                           - name
@@ -1472,6 +1476,8 @@ spec:
                               items:
                                 properties:
                                   name:
+                                    type: string
+                                  request:
                                     type: string
                                 required:
                                 - name

--- a/charts/sn-operator/crds/k8s.streamnative.io_oxiaclusters.yaml
+++ b/charts/sn-operator/crds/k8s.streamnative.io_oxiaclusters.yaml
@@ -37,6 +37,8 @@ spec:
                           properties:
                             name:
                               type: string
+                            request:
+                              type: string
                           required:
                           - name
                           type: object
@@ -989,6 +991,8 @@ spec:
                                     properties:
                                       name:
                                         type: string
+                                      request:
+                                        type: string
                                     required:
                                     - name
                                     type: object
@@ -1168,6 +1172,8 @@ spec:
                             items:
                               properties:
                                 name:
+                                  type: string
+                                request:
                                   type: string
                               required:
                               - name
@@ -1502,6 +1508,8 @@ spec:
                                   items:
                                     properties:
                                       name:
+                                        type: string
+                                      request:
                                         type: string
                                     required:
                                     - name
@@ -1865,6 +1873,8 @@ spec:
                           properties:
                             name:
                               type: string
+                            request:
+                              type: string
                           required:
                           - name
                           type: object
@@ -2063,6 +2073,28 @@ spec:
                   - ready
                   - shards
                   type: object
+                type: array
+              pendingChanges:
+                items:
+                  properties:
+                    action:
+                      type: string
+                    apiVersion:
+                      type: string
+                    diff:
+                      type: string
+                    kind:
+                      type: string
+                    name:
+                      type: string
+                  required:
+                  - action
+                  - apiVersion
+                  - diff
+                  - kind
+                  - name
+                  type: object
+                nullable: true
                 type: array
               serverStatus:
                 properties:

--- a/charts/sn-operator/crds/k8s.streamnative.io_pfsqlclusters.yaml
+++ b/charts/sn-operator/crds/k8s.streamnative.io_pfsqlclusters.yaml
@@ -259,6 +259,8 @@ spec:
                           properties:
                             name:
                               type: string
+                            request:
+                              type: string
                           required:
                           - name
                           type: object

--- a/charts/sn-operator/crds/k8s.streamnative.io_pulsarcoordinators.yaml
+++ b/charts/sn-operator/crds/k8s.streamnative.io_pulsarcoordinators.yaml
@@ -151,6 +151,8 @@ spec:
                               properties:
                                 name:
                                   type: string
+                                request:
+                                  type: string
                               required:
                               - name
                               type: object
@@ -178,6 +180,8 @@ spec:
                       retentionTime:
                         type: string
                       scrapeInterval:
+                        type: string
+                      scrapeTimeout:
                         type: string
                       serviceAccountName:
                         type: string
@@ -299,6 +303,8 @@ spec:
                             items:
                               properties:
                                 name:
+                                  type: string
+                                request:
                                   type: string
                               required:
                               - name
@@ -491,6 +497,8 @@ spec:
                             items:
                               properties:
                                 name:
+                                  type: string
+                                request:
                                   type: string
                               required:
                               - name

--- a/charts/sn-operator/crds/k8s.streamnative.io_unilinks.yaml
+++ b/charts/sn-operator/crds/k8s.streamnative.io_unilinks.yaml
@@ -88,6 +88,8 @@ spec:
                           properties:
                             name:
                               type: string
+                            request:
+                              type: string
                           required:
                           - name
                           type: object

--- a/charts/sn-operator/crds/k8s.streamnative.io_unilinkschemas.yaml
+++ b/charts/sn-operator/crds/k8s.streamnative.io_unilinkschemas.yaml
@@ -61,6 +61,8 @@ spec:
                           properties:
                             name:
                               type: string
+                            request:
+                              type: string
                           required:
                           - name
                           type: object

--- a/charts/sn-operator/crds/pulsar.streamnative.io_pulsarbrokerrevisions.yaml
+++ b/charts/sn-operator/crds/pulsar.streamnative.io_pulsarbrokerrevisions.yaml
@@ -44,6 +44,61 @@ spec:
             type: object
           spec:
             properties:
+              advertisedListeners:
+                items:
+                  properties:
+                    hostTemplate:
+                      type: string
+                    name:
+                      maxLength: 63
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                      type: string
+                    protocols:
+                      properties:
+                        kafka:
+                          properties:
+                            advertisedPort:
+                              format: int32
+                              maximum: 65535
+                              minimum: 1
+                              type: integer
+                            containerPort:
+                              format: int32
+                              maximum: 65535
+                              minimum: 1
+                              type: integer
+                            enabled:
+                              type: boolean
+                            scheme:
+                              type: string
+                          type: object
+                        pulsar:
+                          properties:
+                            advertisedPort:
+                              format: int32
+                              maximum: 65535
+                              minimum: 1
+                              type: integer
+                            containerPort:
+                              format: int32
+                              maximum: 65535
+                              minimum: 1
+                              type: integer
+                            enabled:
+                              type: boolean
+                            scheme:
+                              type: string
+                          type: object
+                      type: object
+                  required:
+                  - hostTemplate
+                  - name
+                  type: object
+                maxItems: 10
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
               apiObjects:
                 properties:
                   brokerConfigMap:
@@ -215,6 +270,30 @@ spec:
                         type: array
                     type: object
                   internalService:
+                    properties:
+                      managed:
+                        type: boolean
+                      metadata:
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            nullable: true
+                            type: object
+                          labels:
+                            additionalProperties:
+                              type: string
+                            nullable: true
+                            type: object
+                          name:
+                            type: string
+                        type: object
+                      updatePolicy:
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  kafkaFunctionMeshConfigMap:
                     properties:
                       managed:
                         type: boolean
@@ -526,6 +605,17 @@ spec:
                                   type: string
                                 issuerUrl:
                                   type: string
+                                publicKeyFilePath:
+                                  type: string
+                                publicKeySecretRef:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
                                 requiredScope:
                                   type: string
                                 scopeClaim:
@@ -545,6 +635,15 @@ spec:
                           revocationListLoadIntervalInSecs:
                             format: int32
                             type: integer
+                          revocationListSecretRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                            required:
+                            - name
+                            type: object
                           revocationListUrl:
                             type: string
                           skipRevocationListValidationOnRevocationListInitFailure:
@@ -559,6 +658,12 @@ spec:
                             type: string
                           tokenSecretKey:
                             type: string
+                        type: object
+                      mtls:
+                        nullable: true
+                        properties:
+                          enabled:
+                            type: boolean
                         type: object
                     type: object
                   authorization:
@@ -593,6 +698,13 @@ spec:
                             type: string
                           token:
                             type: string
+                        type: object
+                      mtls:
+                        properties:
+                          certSecretName:
+                            type: string
+                        required:
+                        - certSecretName
                         type: object
                     type: object
                   clusterName:
@@ -1640,6 +1752,8 @@ spec:
                                         properties:
                                           name:
                                             type: string
+                                          request:
+                                            type: string
                                         required:
                                         - name
                                         type: object
@@ -1819,6 +1933,8 @@ spec:
                                 items:
                                   properties:
                                     name:
+                                      type: string
+                                    request:
                                       type: string
                                   required:
                                   - name
@@ -2153,6 +2269,8 @@ spec:
                                       items:
                                         properties:
                                           name:
+                                            type: string
+                                          request:
                                             type: string
                                         required:
                                         - name
@@ -2508,8 +2626,6 @@ spec:
                         format: int32
                         minimum: 0
                         type: integer
-                    required:
-                    - image
                     type: object
                   concurrentUnloadPerSecond:
                     format: int64
@@ -2544,6 +2660,18 @@ spec:
                             type: string
                           python:
                             type: string
+                          snJava:
+                            type: string
+                        type: object
+                      functionState:
+                        properties:
+                          oxia:
+                            properties:
+                              cluster:
+                                type: string
+                            required:
+                            - cluster
+                            type: object
                         type: object
                       labels:
                         additionalProperties:
@@ -3118,6 +3246,55 @@ spec:
               metadataStoreUrl:
                 nullable: true
                 type: string
+              networking:
+                properties:
+                  podService:
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      enabled:
+                        default: true
+                        type: boolean
+                      labels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      ports:
+                        items:
+                          properties:
+                            appProtocol:
+                              type: string
+                            name:
+                              type: string
+                            nodePort:
+                              format: int32
+                              type: integer
+                            port:
+                              format: int32
+                              type: integer
+                            protocol:
+                              default: TCP
+                              type: string
+                            targetPort:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - port
+                          type: object
+                        type: array
+                      type:
+                        default: ClusterIP
+                        enum:
+                        - ClusterIP
+                        - LoadBalancer
+                        - NodePort
+                        type: string
+                    type: object
+                type: object
               pod:
                 properties:
                   affinity:
@@ -3851,6 +4028,8 @@ spec:
                                 properties:
                                   name:
                                     type: string
+                                  request:
+                                    type: string
                                 required:
                                 - name
                                 type: object
@@ -4030,6 +4209,8 @@ spec:
                         items:
                           properties:
                             name:
+                              type: string
+                            request:
                               type: string
                           required:
                           - name
@@ -4364,6 +4545,8 @@ spec:
                               items:
                                 properties:
                                   name:
+                                    type: string
+                                  request:
                                     type: string
                                 required:
                                 - name

--- a/charts/sn-operator/crds/pulsar.streamnative.io_pulsarbrokers.yaml
+++ b/charts/sn-operator/crds/pulsar.streamnative.io_pulsarbrokers.yaml
@@ -44,6 +44,61 @@ spec:
             type: object
           spec:
             properties:
+              advertisedListeners:
+                items:
+                  properties:
+                    hostTemplate:
+                      type: string
+                    name:
+                      maxLength: 63
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                      type: string
+                    protocols:
+                      properties:
+                        kafka:
+                          properties:
+                            advertisedPort:
+                              format: int32
+                              maximum: 65535
+                              minimum: 1
+                              type: integer
+                            containerPort:
+                              format: int32
+                              maximum: 65535
+                              minimum: 1
+                              type: integer
+                            enabled:
+                              type: boolean
+                            scheme:
+                              type: string
+                          type: object
+                        pulsar:
+                          properties:
+                            advertisedPort:
+                              format: int32
+                              maximum: 65535
+                              minimum: 1
+                              type: integer
+                            containerPort:
+                              format: int32
+                              maximum: 65535
+                              minimum: 1
+                              type: integer
+                            enabled:
+                              type: boolean
+                            scheme:
+                              type: string
+                          type: object
+                      type: object
+                  required:
+                  - hostTemplate
+                  - name
+                  type: object
+                maxItems: 10
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
               apiObjects:
                 properties:
                   brokerConfigMap:
@@ -215,6 +270,30 @@ spec:
                         type: array
                     type: object
                   internalService:
+                    properties:
+                      managed:
+                        type: boolean
+                      metadata:
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            nullable: true
+                            type: object
+                          labels:
+                            additionalProperties:
+                              type: string
+                            nullable: true
+                            type: object
+                          name:
+                            type: string
+                        type: object
+                      updatePolicy:
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  kafkaFunctionMeshConfigMap:
                     properties:
                       managed:
                         type: boolean
@@ -863,6 +942,17 @@ spec:
                                   type: string
                                 issuerUrl:
                                   type: string
+                                publicKeyFilePath:
+                                  type: string
+                                publicKeySecretRef:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
                                 requiredScope:
                                   type: string
                                 scopeClaim:
@@ -882,6 +972,15 @@ spec:
                           revocationListLoadIntervalInSecs:
                             format: int32
                             type: integer
+                          revocationListSecretRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                            required:
+                            - name
+                            type: object
                           revocationListUrl:
                             type: string
                           skipRevocationListValidationOnRevocationListInitFailure:
@@ -896,6 +995,12 @@ spec:
                             type: string
                           tokenSecretKey:
                             type: string
+                        type: object
+                      mtls:
+                        nullable: true
+                        properties:
+                          enabled:
+                            type: boolean
                         type: object
                     type: object
                   authorization:
@@ -930,6 +1035,13 @@ spec:
                             type: string
                           token:
                             type: string
+                        type: object
+                      mtls:
+                        properties:
+                          certSecretName:
+                            type: string
+                        required:
+                        - certSecretName
                         type: object
                     type: object
                   clusterName:
@@ -1977,6 +2089,8 @@ spec:
                                         properties:
                                           name:
                                             type: string
+                                          request:
+                                            type: string
                                         required:
                                         - name
                                         type: object
@@ -2156,6 +2270,8 @@ spec:
                                 items:
                                   properties:
                                     name:
+                                      type: string
+                                    request:
                                       type: string
                                   required:
                                   - name
@@ -2490,6 +2606,8 @@ spec:
                                       items:
                                         properties:
                                           name:
+                                            type: string
+                                          request:
                                             type: string
                                         required:
                                         - name
@@ -2845,8 +2963,6 @@ spec:
                         format: int32
                         minimum: 0
                         type: integer
-                    required:
-                    - image
                     type: object
                   concurrentUnloadPerSecond:
                     format: int64
@@ -2881,6 +2997,18 @@ spec:
                             type: string
                           python:
                             type: string
+                          snJava:
+                            type: string
+                        type: object
+                      functionState:
+                        properties:
+                          oxia:
+                            properties:
+                              cluster:
+                                type: string
+                            required:
+                            - cluster
+                            type: object
                         type: object
                       labels:
                         additionalProperties:
@@ -3936,6 +4064,8 @@ spec:
                                 properties:
                                   name:
                                     type: string
+                                  request:
+                                    type: string
                                 required:
                                 - name
                                 type: object
@@ -4115,6 +4245,8 @@ spec:
                         items:
                           properties:
                             name:
+                              type: string
+                            request:
                               type: string
                           required:
                           - name
@@ -4449,6 +4581,8 @@ spec:
                               items:
                                 properties:
                                   name:
+                                    type: string
+                                  request:
                                     type: string
                                 required:
                                 - name
@@ -5059,6 +5193,55 @@ spec:
               metadataStoreUrl:
                 nullable: true
                 type: string
+              networking:
+                properties:
+                  podService:
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      enabled:
+                        default: true
+                        type: boolean
+                      labels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      ports:
+                        items:
+                          properties:
+                            appProtocol:
+                              type: string
+                            name:
+                              type: string
+                            nodePort:
+                              format: int32
+                              type: integer
+                            port:
+                              format: int32
+                              type: integer
+                            protocol:
+                              default: TCP
+                              type: string
+                            targetPort:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - port
+                          type: object
+                        type: array
+                      type:
+                        default: ClusterIP
+                        enum:
+                        - ClusterIP
+                        - LoadBalancer
+                        - NodePort
+                        type: string
+                    type: object
+                type: object
               pod:
                 properties:
                   affinity:
@@ -5792,6 +5975,8 @@ spec:
                                 properties:
                                   name:
                                     type: string
+                                  request:
+                                    type: string
                                 required:
                                 - name
                                 type: object
@@ -5971,6 +6156,8 @@ spec:
                         items:
                           properties:
                             name:
+                              type: string
+                            request:
                               type: string
                           required:
                           - name
@@ -6305,6 +6492,8 @@ spec:
                               items:
                                 properties:
                                   name:
+                                    type: string
+                                  request:
                                     type: string
                                 required:
                                 - name

--- a/charts/sn-operator/crds/pulsar.streamnative.io_pulsarfunctionsworkers.yaml
+++ b/charts/sn-operator/crds/pulsar.streamnative.io_pulsarfunctionsworkers.yaml
@@ -118,6 +118,30 @@ spec:
                           type: string
                         type: array
                     type: object
+                  kafkaFunctionMeshConfigMap:
+                    properties:
+                      managed:
+                        type: boolean
+                      metadata:
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            nullable: true
+                            type: object
+                          labels:
+                            additionalProperties:
+                              type: string
+                            nullable: true
+                            type: object
+                          name:
+                            type: string
+                        type: object
+                      updatePolicy:
+                        items:
+                          type: string
+                        type: array
+                    type: object
                   pdb:
                     properties:
                       managed:
@@ -735,6 +759,17 @@ spec:
                                   type: string
                                 issuerUrl:
                                   type: string
+                                publicKeyFilePath:
+                                  type: string
+                                publicKeySecretRef:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
                                 requiredScope:
                                   type: string
                                 scopeClaim:
@@ -754,6 +789,15 @@ spec:
                           revocationListLoadIntervalInSecs:
                             format: int32
                             type: integer
+                          revocationListSecretRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                            required:
+                            - name
+                            type: object
                           revocationListUrl:
                             type: string
                           skipRevocationListValidationOnRevocationListInitFailure:
@@ -768,6 +812,12 @@ spec:
                             type: string
                           tokenSecretKey:
                             type: string
+                        type: object
+                      mtls:
+                        nullable: true
+                        properties:
+                          enabled:
+                            type: boolean
                         type: object
                     type: object
                   authorization:
@@ -803,6 +853,13 @@ spec:
                           token:
                             type: string
                         type: object
+                      mtls:
+                        properties:
+                          certSecretName:
+                            type: string
+                        required:
+                        - certSecretName
+                        type: object
                     type: object
                   custom:
                     additionalProperties:
@@ -834,6 +891,18 @@ spec:
                             type: string
                           python:
                             type: string
+                          snJava:
+                            type: string
+                        type: object
+                      functionState:
+                        properties:
+                          oxia:
+                            properties:
+                              cluster:
+                                type: string
+                            required:
+                            - cluster
+                            type: object
                         type: object
                       labels:
                         additionalProperties:
@@ -1856,6 +1925,8 @@ spec:
                                 properties:
                                   name:
                                     type: string
+                                  request:
+                                    type: string
                                 required:
                                 - name
                                 type: object
@@ -2035,6 +2106,8 @@ spec:
                         items:
                           properties:
                             name:
+                              type: string
+                            request:
                               type: string
                           required:
                           - name
@@ -2369,6 +2442,8 @@ spec:
                               items:
                                 properties:
                                   name:
+                                    type: string
+                                  request:
                                     type: string
                                 required:
                                 - name

--- a/charts/sn-operator/crds/pulsar.streamnative.io_pulsarproxies.yaml
+++ b/charts/sn-operator/crds/pulsar.streamnative.io_pulsarproxies.yaml
@@ -806,6 +806,17 @@ spec:
                                   type: string
                                 issuerUrl:
                                   type: string
+                                publicKeyFilePath:
+                                  type: string
+                                publicKeySecretRef:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
                                 requiredScope:
                                   type: string
                                 scopeClaim:
@@ -825,6 +836,15 @@ spec:
                           revocationListLoadIntervalInSecs:
                             format: int32
                             type: integer
+                          revocationListSecretRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                            required:
+                            - name
+                            type: object
                           revocationListUrl:
                             type: string
                           skipRevocationListValidationOnRevocationListInitFailure:
@@ -839,6 +859,12 @@ spec:
                             type: string
                           tokenSecretKey:
                             type: string
+                        type: object
+                      mtls:
+                        nullable: true
+                        properties:
+                          enabled:
+                            type: boolean
                         type: object
                     type: object
                   authorization:
@@ -871,6 +897,13 @@ spec:
                             type: string
                           token:
                             type: string
+                        type: object
+                      mtls:
+                        properties:
+                          certSecretName:
+                            type: string
+                        required:
+                        - certSecretName
                         type: object
                     type: object
                   clusterName:
@@ -1879,6 +1912,8 @@ spec:
                                 properties:
                                   name:
                                     type: string
+                                  request:
+                                    type: string
                                 required:
                                 - name
                                 type: object
@@ -2058,6 +2093,8 @@ spec:
                         items:
                           properties:
                             name:
+                              type: string
+                            request:
                               type: string
                           required:
                           - name
@@ -2392,6 +2429,8 @@ spec:
                               items:
                                 properties:
                                   name:
+                                    type: string
+                                  request:
                                     type: string
                                 required:
                                 - name

--- a/charts/sn-operator/crds/zookeeper.streamnative.io_zookeeperclusters.yaml
+++ b/charts/sn-operator/crds/zookeeper.streamnative.io_zookeeperclusters.yaml
@@ -1638,6 +1638,8 @@ spec:
                                 properties:
                                   name:
                                     type: string
+                                  request:
+                                    type: string
                                 required:
                                 - name
                                 type: object
@@ -1817,6 +1819,8 @@ spec:
                         items:
                           properties:
                             name:
+                              type: string
+                            request:
                               type: string
                           required:
                           - name
@@ -2151,6 +2155,8 @@ spec:
                               items:
                                 properties:
                                   name:
+                                    type: string
+                                  request:
                                     type: string
                                 required:
                                 - name

--- a/charts/sn-operator/templates/rules.yaml
+++ b/charts/sn-operator/templates/rules.yaml
@@ -132,6 +132,7 @@ rules:
     - leases
   verbs:
     - create
+    - delete
     - get
     - list
     - update
@@ -561,6 +562,20 @@ rules:
     - storage.k8s.io
   resources:
     - storageclasses
+  verbs:
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
+- apiGroups:
+    - monitoring.coreos.com
+  resources:
+    - podmonitors
+    - prometheuses
+    - servicemonitors
   verbs:
     - create
     - delete


### PR DESCRIPTION
## Summary
- Upgrade sn-operator from v0.13.12 to v0.14.2
- Update chart version from v0.13.3 to v0.14.0
- Update all CRD files from sn-operator v0.14.2
- Add new RBAC rules for `monitoring.coreos.com` resources (podmonitors, prometheuses, servicemonitors)
- Add `delete` permission for `coordination.k8s.io/leases`

## Test plan
- [ ] Deploy the upgraded operator in a test cluster
- [ ] Verify CRDs are applied correctly
- [ ] Verify RBAC permissions work as expected