### PR TITLE
fix: disable Oxia monitoring in example by default

### DIFF
--- a/oxia/pulsar-oxia.yaml
+++ b/oxia/pulsar-oxia.yaml
@@ -16,7 +16,7 @@ metadata:
   name: private-cloud
   namespace: pulsar
 spec:
-  monitoringEnabled: true
+  monitoringEnabled: false
   image: oxia/oxia:0.16.7
   imagePullPolicy: IfNotPresent
   server:


### PR DESCRIPTION
## Motivation
- The Oxia example should run on local and test Kubernetes clusters that do not install Prometheus Operator CRDs.
- With monitoring enabled, the operator tries to reconcile PodMonitor resources and blocks Oxia startup when those CRDs are absent.

## Modifications
- Set `OxiaCluster.spec.monitoringEnabled` to `false` in `oxia/pulsar-oxia.yaml`.

## Testing
- Applied `oxia/pulsar-oxia.yaml` to a local kind cluster.
- Verified Oxia, BookKeeper, broker, proxy, and coordinator became ready.
- Ran broker healthcheck and Pulsar produce/consume smoke test successfully.
- Ran `kubectl apply --dry-run=client --validate=false -f oxia/pulsar-oxia.yaml`.
- Ran `git diff --check`.
